### PR TITLE
Replace getNameTag() with getDisplayName()

### DIFF
--- a/src/Niekert/DiscordMCPE/Events/EventListener.php
+++ b/src/Niekert/DiscordMCPE/Events/EventListener.php
@@ -5,6 +5,7 @@ namespace Niekert\DiscordMCPE\Events;
 use Niekert\DiscordMCPE\Main;
 use pocketmine\event\Listener;
 use pocketmine\utils\Config;
+use pocketmine\utils\TextFormat as C;
 use pocketmine\event\player\{PlayerJoinEvent,PlayerQuitEvent, PlayerDeathEvent, PlayerChatEvent};;
 
 class EventListener implements Listener
@@ -24,7 +25,7 @@ class EventListener implements Listener
     public function onJoin(PlayerJoinEvent $event){
         $playername = $event->getPlayer()->getDisplayName();
         if($this->main->joinopt !== "0"){
-            $this->main->sendMessage($this->webhook, str_replace("{player}",$playername,$this->main->joinopt));
+            $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->joinopt));
         }
     }
 
@@ -34,7 +35,7 @@ class EventListener implements Listener
     public function onQuit(PlayerQuitEvent $event){
         $playername = $event->getPlayer()->getDisplayName();
         if($this->main->quitopt !== "0"){
-            $this->main->sendMessage($this->webhook, str_replace("{player}",$playername,$this->main->quitopt));
+            $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->quitopt));
         }
     }
 
@@ -44,7 +45,7 @@ class EventListener implements Listener
     public function onDeath(PlayerDeathEvent $event){
         $playername = $event->getEntity()->getDisplayName();
         if($this->main->deathopt !== "0"){
-            $this->main->sendMessage($this->webhook, str_replace("{player}",$playername,$this->main->deathopt));
+            $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->deathopt));
         }
     }
 

--- a/src/Niekert/DiscordMCPE/Events/EventListener.php
+++ b/src/Niekert/DiscordMCPE/Events/EventListener.php
@@ -7,7 +7,6 @@ use pocketmine\event\Listener;
 use pocketmine\utils\Config;
 use pocketmine\event\player\{PlayerJoinEvent,PlayerQuitEvent, PlayerDeathEvent, PlayerChatEvent};;
 
-
 class EventListener implements Listener
 {
     private $main,$config,$webhook;
@@ -23,7 +22,7 @@ class EventListener implements Listener
      * @param PlayerJoinEvent $event
      */
     public function onJoin(PlayerJoinEvent $event){
-        $playername = $event->getPlayer()->getNameTag();
+        $playername = $event->getPlayer()->getDisplayName();
         if($this->main->joinopt !== "0"){
             $this->main->sendMessage($this->webhook, str_replace("{player}",$playername,$this->main->joinopt));
         }
@@ -33,7 +32,7 @@ class EventListener implements Listener
      * @param PlayerQuitEvent $event
      */
     public function onQuit(PlayerQuitEvent $event){
-        $playername = $event->getPlayer()->getNameTag();
+        $playername = $event->getPlayer()->getDisplayName();
         if($this->main->quitopt !== "0"){
             $this->main->sendMessage($this->webhook, str_replace("{player}",$playername,$this->main->quitopt));
         }
@@ -43,7 +42,7 @@ class EventListener implements Listener
      * @param PlayerDeathEvent $event
      */
     public function onDeath(PlayerDeathEvent $event){
-        $playername = $event->getEntity()->getNameTag();
+        $playername = $event->getEntity()->getDisplayName();
         if($this->main->deathopt !== "0"){
             $this->main->sendMessage($this->webhook, str_replace("{player}",$playername,$this->main->deathopt));
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16523741/37561851-a28be652-29fd-11e8-8e5e-50f9140b0695.png)
![image](https://user-images.githubusercontent.com/16523741/37561854-b001de86-29fd-11e8-836b-2e60710ea9cd.png)
If you use getNameTag(), it'll show the color codes on quit.
If you use getDisplayName(), it will just get their nickname instead. In case the nickname uses color codes, it cleans the formatting with TextFormat::clean().

Optionally, you could just use getName() if you wanted and not need to use TextFormat::clean().