### PR TITLE
Support for PurePerm Ranks + Small Performance Improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 images/Thumbs.db
 idea_temp_LocalResourceRootsList
 /config.yml
-.idea/
+\.idea/

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -6,5 +6,4 @@ projects:
     icon: logo.png
     model: default
     path: ""
-
 ...

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,29 +1,17 @@
 name: Discord-MCPE
 author: Niekert
-version: "1.0.1"
+version: "1.0.2"
 api:
-- 2.0.0
-- 3.0.0
-- 3.0.0-ALPHA1
-- 3.0.0-ALPHA2
-- 3.0.0-ALPHA3
-- 3.0.0-ALPHA4
-- 3.0.0-ALPHA5
-- 3.0.0-ALPHA6
-- 3.0.0-ALPHA7
-- 3.0.0-ALPHA8
-- 3.0.0-ALPHA9
 - 3.0.0-ALPHA10
 - 3.0.0-ALPHA11
+softdepend: PurePerms
 main: Niekert\DiscordMCPE\Main
-
 commands:
     discord:
         description: Send an message to Discord!
         permission: discord.send
         usage: /discord MESSAGE
         aliases: [dc]
-
 permissions:
     discord.send:
         default: op

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -23,8 +23,6 @@ chat_username: ""
 chat_format: "[{player}] {message}" 
 # Format in discord that the plugin uses when sending a message. {player} and {message} can be used.
 
-
-
 ############################################################
 #                     Messages on Event                    #
 #   These messages are triggered on an event such as when  #
@@ -48,8 +46,6 @@ quit_message: ""
 death_message: "" 
 # Message sent when player get killed. {player} can be used.
 
-
-
 ############################################################
 #                       Other Options                      #
 #  It is not recommended that you change these, especially #
@@ -67,12 +63,15 @@ chat_prefix: "!"
 chat: false
 # Send everything to Discord. Recommended to keep this disabled, but it can be used.
 
+pureperms: false
+# Support for PurePerms rank names.
+
 debug: false
 # Show error messages. Set to 1 to enable.
 
 #####################################################
 #     UNDER NO CIRCUMSTANCES SHOULD YOU EDIT THE    #
 #                  FOLLOWING LINE!                  #
-Version: "1.0.1"
+Version: "1.0.2"
 #     Thank you for not editing the line above!     #
 #####################################################

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -20,8 +20,8 @@ username: ""
 chat_username: "" 
 # The username of the plugin for /discord and when someone chats. Set to 0 to use default.
 
-chat_format: "[{player}] {message}" 
-# Format in discord that the plugin uses when sending a message. {player} and {message} can be used.
+chat_format: "[{player}] {message}"
+# Format in discord that the plugin uses when sending a message. {rank}, {player}, and {message} can be used.
 
 ############################################################
 #                     Messages on Event                    #
@@ -38,13 +38,13 @@ shutdown_message: ""
 # Message sent when server stops.
 
 join_message: "" 
-# Message sent when player joins. {player} can be used.
+# Message sent when player joins. {player} and {rank} can be used.
 
 quit_message: "" 
-# Message sent when player leaves. {player} can be used.
+# Message sent when player leaves. {player} and {rank} can be used.
 
 death_message: "" 
-# Message sent when player get killed. {player} can be used.
+# Message sent when player get killed. {player} and {rank} can be used.
 
 ############################################################
 #                       Other Options                      #
@@ -64,7 +64,8 @@ chat: false
 # Send everything to Discord. Recommended to keep this disabled, but it can be used.
 
 pureperms: false
-# Support for PurePerms rank names.
+# Support for PurePerms rank names. PurePerms ranks use the prefix {rank}.
+# If not enabled, {rank} tags will only show as {rank}.
 
 debug: false
 # Show error messages. Set to 1 to enable.

--- a/src/Niekert/DiscordMCPE/Events/EventListener.php
+++ b/src/Niekert/DiscordMCPE/Events/EventListener.php
@@ -19,8 +19,8 @@ class EventListener implements Listener
     public function __construct(Main $plugin)
     {
         $this->main = $plugin;
-        $this->config = new Config($this->main->getDataFolder() . "config.yml", Config::YAML, array());
-        $this->webhook = $this->config->get("webhook_url");
+        $this->config = new Config($this->main->getDataFolder() . 'config.yml', Config::YAML, array());
+        $this->webhook = $this->config->get('webhook_url');
         $this->ppa = $this->main->getServer()->getPluginManager()->getPlugin('PurePerms');
     }
 
@@ -31,11 +31,11 @@ class EventListener implements Listener
     public function onJoin(PlayerJoinEvent $event)
     {
         $playername = $event->getPlayer()->getDisplayName();
-        if ($this->main->joinopt !== "0") {
+        if ($this->main->joinopt !== '0') {
             if ($this->main->pp !== null) {
-                $this->main->sendMessage($this->webhook, str_replace("{rank}", C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), str_replace("{player}", C::clean($playername), $this->main->joinopt)));
+                $this->main->sendMessage($this->webhook, str_replace('{rank}', C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), str_replace('{player}', C::clean($playername), $this->main->joinopt)));
             } else {
-                $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->joinopt));
+                $this->main->sendMessage($this->webhook, str_replace('{player}', C::clean($playername), $this->main->joinopt));
             }
         }
     }
@@ -46,11 +46,11 @@ class EventListener implements Listener
     public function onQuit(PlayerQuitEvent $event)
     {
         $playername = $event->getPlayer()->getDisplayName();
-        if ($this->main->quitopt !== "0") {
+        if ($this->main->quitopt !== '0') {
             if ($this->main->pp !== null) {
-                $this->main->sendMessage($this->webhook, str_replace("{rank}", C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), str_replace("{player}", C::clean($playername), $this->main->quitopt)));
+                $this->main->sendMessage($this->webhook, str_replace('{rank}', C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), str_replace('{player}', C::clean($playername), $this->main->quitopt)));
             } else {
-                $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->quitopt));
+                $this->main->sendMessage($this->webhook, str_replace('{player}', C::clean($playername), $this->main->quitopt));
             }
         }
     }
@@ -61,11 +61,11 @@ class EventListener implements Listener
     public function onDeath(PlayerDeathEvent $event)
     {
         $playername = $event->getEntity()->getDisplayName();
-        if ($this->main->deathopt !== "0") {
+        if ($this->main->deathopt !== '0') {
             if ($this->main->pp !== null) {
-                $this->main->sendMessage($this->webhook, str_replace("{rank}", C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), str_replace("{player}", C::clean($playername), $this->main->deathopt)));
+                $this->main->sendMessage($this->webhook, str_replace('{rank}', C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), str_replace('{player}', C::clean($playername), $this->main->deathopt)));
             } else {
-                $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->deathopt));
+                $this->main->sendMessage($this->webhook, str_replace('{player}', C::clean($playername), $this->main->deathopt));
             }
         }
     }
@@ -79,15 +79,15 @@ class EventListener implements Listener
         $message = $event->getMessage();
         $sender = $event->getPlayer();
         $chaturl = $this->main->chaturl;
-        if ($this->main->chatprefix !== "0") {
+        if ($this->main->chatprefix !== '0') {
             if ($this->main->pp !== null) {
-                $format = str_replace(["{rank}", "{player}", "{message}"], [C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), C::clean($sender->getName()), ltrim($message, $this->main->chatprefix)], $this->main->chatformat);
+                $format = str_replace(['{rank}', '{player}', '{message}'], [C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), C::clean($sender->getName()), ltrim($message, $this->main->chatprefix)], $this->main->chatformat);
                 if (substr($message, 0, 1) === $this->main->chatprefix) {
                     $event->setCancelled();
                     $this->main->sendMessage($chaturl, $format, $sender->getName(), $this->main->chatuser);
                 }
             } else {
-                $format = str_replace(["{player}", "{message}"], [C::clean($sender->getName()), ltrim($message, $this->main->chatprefix)], $this->main->chatformat);
+                $format = str_replace(['{player}', '{message}'], [C::clean($sender->getName()), ltrim($message, $this->main->chatprefix)], $this->main->chatformat);
                 if (substr($message, 0, 1) === $this->main->chatprefix) {
                     $event->setCancelled();
                     $this->main->sendMessage($chaturl, $format, $sender->getName(), $this->main->chatuser);
@@ -96,10 +96,10 @@ class EventListener implements Listener
             if ($this->main->chatopt) {
                 if ($this->main->pp !== null) {
                     $format = str_replace(array('{rank}', '{player}', '{message}'), array(C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), C::clean($sender->getName()), $message), $this->main->chatformat);
-                    $this->main->sendMessage($chaturl, $format, "nolog", $this->main->chatuser);
+                    $this->main->sendMessage($chaturl, $format, 'nolog', $this->main->chatuser);
                 } else {
                     $format = str_replace(array('{player}', '{message}'), array(C::clean($sender->getName()), $message), $this->main->chatformat);
-                    $this->main->sendMessage($chaturl, $format, "nolog", $this->main->chatuser);
+                    $this->main->sendMessage($chaturl, $format, 'nolog', $this->main->chatuser);
                 }
             }
         }

--- a/src/Niekert/DiscordMCPE/Events/EventListener.php
+++ b/src/Niekert/DiscordMCPE/Events/EventListener.php
@@ -12,6 +12,10 @@ class EventListener implements Listener
 {
     private $main, $config, $webhook, $ppa;
 
+    /**
+     * EventListener constructor.
+     * @param Main $plugin
+     */
     public function __construct(Main $plugin)
     {
         $this->main = $plugin;
@@ -20,6 +24,7 @@ class EventListener implements Listener
         $this->ppa = $this->main->getServer()->getPluginManager()->getPlugin('PurePerms');
     }
 
+
     /**
      * @param PlayerJoinEvent $event
      */
@@ -27,8 +32,8 @@ class EventListener implements Listener
     {
         $playername = $event->getPlayer()->getDisplayName();
         if ($this->main->joinopt !== "0") {
-            if ($this->main->pp == true){
-                $this->main->sendMessage($this->webhook, str_replace("{player}", $this->ppa->getUserDataMgr()->getGroup($playername), C::clean($playername), $this->main->joinopt));
+            if ($this->main->pp !== null) {
+                $this->main->sendMessage($this->webhook, str_replace("{rank}", C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), str_replace("{player}", C::clean($playername), $this->main->joinopt)));
             } else {
                 $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->joinopt));
             }
@@ -42,7 +47,11 @@ class EventListener implements Listener
     {
         $playername = $event->getPlayer()->getDisplayName();
         if ($this->main->quitopt !== "0") {
-            $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->quitopt));
+            if ($this->main->pp !== null) {
+                $this->main->sendMessage($this->webhook, str_replace("{rank}", C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), str_replace("{player}", C::clean($playername), $this->main->quitopt)));
+            } else {
+                $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->quitopt));
+            }
         }
     }
 
@@ -53,7 +62,11 @@ class EventListener implements Listener
     {
         $playername = $event->getEntity()->getDisplayName();
         if ($this->main->deathopt !== "0") {
-            $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->deathopt));
+            if ($this->main->pp !== null) {
+                $this->main->sendMessage($this->webhook, str_replace("{rank}", C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), str_replace("{player}", C::clean($playername), $this->main->deathopt)));
+            } else {
+                $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->deathopt));
+            }
         }
     }
 
@@ -67,15 +80,28 @@ class EventListener implements Listener
         $sender = $event->getPlayer();
         $chaturl = $this->main->chaturl;
         if ($this->main->chatprefix !== "0") {
-            $format = str_replace(["{player}", "{message}"], [$sender->getName(), ltrim($message, $this->main->chatprefix)], $this->main->chatformat);
-            if (substr($message, 0, 1) === $this->main->chatprefix) {
-                $event->setCancelled();
-                $this->main->sendMessage($chaturl, $format, $sender->getName(), $this->main->chatuser);
+            if ($this->main->pp !== null) {
+                $format = str_replace(["{rank}", "{player}", "{message}"], [C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), C::clean($sender->getName()), ltrim($message, $this->main->chatprefix)], $this->main->chatformat);
+                if (substr($message, 0, 1) === $this->main->chatprefix) {
+                    $event->setCancelled();
+                    $this->main->sendMessage($chaturl, $format, $sender->getName(), $this->main->chatuser);
+                }
+            } else {
+                $format = str_replace(["{player}", "{message}"], [C::clean($sender->getName()), ltrim($message, $this->main->chatprefix)], $this->main->chatformat);
+                if (substr($message, 0, 1) === $this->main->chatprefix) {
+                    $event->setCancelled();
+                    $this->main->sendMessage($chaturl, $format, $sender->getName(), $this->main->chatuser);
+                }
             }
-        }
-        if ($this->main->chatopt) {
-            $format = str_replace(array('{player}', '{message}'), array($sender->getName(), $message), $this->main->chatformat);
-            $this->main->sendMessage($chaturl, $format, "nolog", $this->main->chatuser);
+            if ($this->main->chatopt) {
+                if ($this->main->pp !== null) {
+                    $format = str_replace(array('{rank}', '{player}', '{message}'), array(C::clean($this->ppa->getUserDataMgr()->getGroup($event->getPlayer())), C::clean($sender->getName()), $message), $this->main->chatformat);
+                    $this->main->sendMessage($chaturl, $format, "nolog", $this->main->chatuser);
+                } else {
+                    $format = str_replace(array('{player}', '{message}'), array(C::clean($sender->getName()), $message), $this->main->chatformat);
+                    $this->main->sendMessage($chaturl, $format, "nolog", $this->main->chatuser);
+                }
+            }
         }
     }
 }

--- a/src/Niekert/DiscordMCPE/Events/EventListener.php
+++ b/src/Niekert/DiscordMCPE/Events/EventListener.php
@@ -6,25 +6,26 @@ use Niekert\DiscordMCPE\Main;
 use pocketmine\event\Listener;
 use pocketmine\utils\Config;
 use pocketmine\utils\TextFormat as C;
-use pocketmine\event\player\{PlayerJoinEvent,PlayerQuitEvent, PlayerDeathEvent, PlayerChatEvent};;
+use pocketmine\event\player\{PlayerJoinEvent, PlayerQuitEvent, PlayerDeathEvent, PlayerChatEvent};;
 
 class EventListener implements Listener
 {
-    private $main,$config,$webhook;
+    private $main, $config, $webhook;
 
     public function __construct(Main $plugin)
     {
         $this->main = $plugin;
-        $this->config = new Config($this->main->getDataFolder(). "config.yml", Config::YAML, array());
+        $this->config = new Config($this->main->getDataFolder() . "config.yml", Config::YAML, array());
         $this->webhook = $this->config->get("webhook_url");
     }
 
     /**
      * @param PlayerJoinEvent $event
      */
-    public function onJoin(PlayerJoinEvent $event){
+    public function onJoin(PlayerJoinEvent $event)
+    {
         $playername = $event->getPlayer()->getDisplayName();
-        if($this->main->joinopt !== "0"){
+        if ($this->main->joinopt !== "0") {
             $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->joinopt));
         }
     }
@@ -32,9 +33,10 @@ class EventListener implements Listener
     /**
      * @param PlayerQuitEvent $event
      */
-    public function onQuit(PlayerQuitEvent $event){
+    public function onQuit(PlayerQuitEvent $event)
+    {
         $playername = $event->getPlayer()->getDisplayName();
-        if($this->main->quitopt !== "0"){
+        if ($this->main->quitopt !== "0") {
             $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->quitopt));
         }
     }
@@ -42,9 +44,10 @@ class EventListener implements Listener
     /**
      * @param PlayerDeathEvent $event
      */
-    public function onDeath(PlayerDeathEvent $event){
+    public function onDeath(PlayerDeathEvent $event)
+    {
         $playername = $event->getEntity()->getDisplayName();
-        if($this->main->deathopt !== "0"){
+        if ($this->main->deathopt !== "0") {
             $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->deathopt));
         }
     }
@@ -52,19 +55,20 @@ class EventListener implements Listener
     /**
      * @param PlayerChatEvent $event
      */
-    public function onChat(PlayerChatEvent $event){
-        if($event->isCancelled()) return;
+    public function onChat(PlayerChatEvent $event)
+    {
+        if ($event->isCancelled()) return;
         $message = $event->getMessage();
         $sender = $event->getPlayer();
         $chaturl = $this->main->chaturl;
-        if($this->main->chatprefix !== "0"){
+        if ($this->main->chatprefix !== "0") {
             $format = str_replace(["{player}", "{message}"], [$sender->getName(), ltrim($message, $this->main->chatprefix)], $this->main->chatformat);
-            if(substr($message, 0, 1 ) === $this->main->chatprefix){
+            if (substr($message, 0, 1) === $this->main->chatprefix) {
                 $event->setCancelled();
                 $this->main->sendMessage($chaturl, $format, $sender->getName(), $this->main->chatuser);
             }
         }
-        if($this->main->chatopt){
+        if ($this->main->chatopt) {
             $format = str_replace(array('{player}', '{message}'), array($sender->getName(), $message), $this->main->chatformat);
             $this->main->sendMessage($chaturl, $format, "nolog", $this->main->chatuser);
         }

--- a/src/Niekert/DiscordMCPE/Events/EventListener.php
+++ b/src/Niekert/DiscordMCPE/Events/EventListener.php
@@ -10,13 +10,14 @@ use pocketmine\event\player\{PlayerJoinEvent, PlayerQuitEvent, PlayerDeathEvent,
 
 class EventListener implements Listener
 {
-    private $main, $config, $webhook;
+    private $main, $config, $webhook, $ppa;
 
     public function __construct(Main $plugin)
     {
         $this->main = $plugin;
         $this->config = new Config($this->main->getDataFolder() . "config.yml", Config::YAML, array());
         $this->webhook = $this->config->get("webhook_url");
+        $this->ppa = $this->main->getServer()->getPluginManager()->getPlugin('PurePerms');
     }
 
     /**
@@ -26,7 +27,11 @@ class EventListener implements Listener
     {
         $playername = $event->getPlayer()->getDisplayName();
         if ($this->main->joinopt !== "0") {
-            $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->joinopt));
+            if ($this->main->pp == true){
+                $this->main->sendMessage($this->webhook, str_replace("{player}", $this->ppa->getUserDataMgr()->getGroup($playername), C::clean($playername), $this->main->joinopt));
+            } else {
+                $this->main->sendMessage($this->webhook, str_replace("{player}", C::clean($playername), $this->main->joinopt));
+            }
         }
     }
 

--- a/src/Niekert/DiscordMCPE/Main.php
+++ b/src/Niekert/DiscordMCPE/Main.php
@@ -13,9 +13,9 @@ use Niekert\DiscordMCPE\Events\EventListener;
 class Main extends PluginBase implements Listener
 {
 
-    public $webhook, $username, $startupopt, $shutdownopt, $joinopt, $quitopt, $deathopt, $debugopt, $commandopt, $chaturl, $chatformat, $chatprefix, $chatopt, $chatuser;
+    public $webhook, $username, $startupopt, $shutdownopt, $joinopt, $quitopt, $deathopt, $debugopt, $commandopt, $chaturl, $chatformat, $chatprefix, $chatopt, $chatuser, $pp;
 
-    private $configversion = "1.0.1";
+    private $configversion = "1.0.2";
 
     public function onLoad()
     {
@@ -27,6 +27,13 @@ class Main extends PluginBase implements Listener
         $this->setvars();
         if ($this->isDisabled()) {
             return;
+        }
+        if ($this->pp == true) {
+            if ($this->getServer()->getPluginManager()->getPlugin('PurePerms') == true) {
+                $this->getServer()->getLogger()->info(C::GREEN . 'PurePerms Compatibility Enabled!');
+            } else {
+                $this->getServer()->getLogger()->info(C::RED . 'PurePerms Compatibility Enabled, but PurePerms could not be found!');
+            }
         }
         $this->getServer()->getPluginManager()->registerEvents(new EventListener($this), $this);
         $this->getLogger()->info(C::GREEN . "Plugin enabled");
@@ -101,6 +108,7 @@ class Main extends PluginBase implements Listener
         $this->chatformat = $this->getConfig()->get("chat_format");
         $this->chatprefix = $this->getConfig()->get("chat_prefix");
         $this->chatopt = $this->getConfig()->get("chat");
+        $this->pp = $this->getConfig()->get("pureperms");
 
         //Some statements
         if ($this->getConfig()->get("chat_username") === "0") {

--- a/src/Niekert/DiscordMCPE/Main.php
+++ b/src/Niekert/DiscordMCPE/Main.php
@@ -10,33 +10,37 @@ use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use Niekert\DiscordMCPE\Events\EventListener;
 
-class Main extends PluginBase implements Listener{
-	
-	public $webhook, $username, $startupopt, $shutdownopt, $joinopt, $quitopt, $deathopt, $debugopt, $commandopt, $chaturl, $chatformat, $chatprefix, $chatopt, $chatuser;
+class Main extends PluginBase implements Listener
+{
 
-	private $configversion = "1.0.1";
+    public $webhook, $username, $startupopt, $shutdownopt, $joinopt, $quitopt, $deathopt, $debugopt, $commandopt, $chaturl, $chatformat, $chatprefix, $chatopt, $chatuser;
 
-    public function onLoad(){
-		$this->getLogger()->info("Plugin loading");
-	}
-		
-	public function onEnable(){
+    private $configversion = "1.0.1";
+
+    public function onLoad()
+    {
+        $this->getLogger()->info("Plugin loading");
+    }
+
+    public function onEnable()
+    {
         $this->setvars();
-        if($this->isDisabled()){
-           return;
+        if ($this->isDisabled()) {
+            return;
         }
         $this->getServer()->getPluginManager()->registerEvents(new EventListener($this), $this);
-		$this->getLogger()->info(C::GREEN."Plugin enabled");
-        if($this->getConfig()->get("start_message") !== "0"){
+        $this->getLogger()->info(C::GREEN . "Plugin enabled");
+        if ($this->getConfig()->get("start_message") !== "0") {
             $this->sendMessage($this->webhook, $this->startupopt, "CONSOLE");
         }
-	}
-	
-	public function onDisable(){
-        $this->getLogger()->info(C::RED."Plugin Disabled");
-		if($this->shutdownopt !== "0" AND !$this->isEnabled()){
-			$this->sendMessage($this->webhook, $this->shutdownopt);
-		}
+    }
+
+    public function onDisable()
+    {
+        $this->getLogger()->info(C::RED . "Plugin Disabled");
+        if ($this->shutdownopt !== "0" AND !$this->isEnabled()) {
+            $this->sendMessage($this->webhook, $this->shutdownopt);
+        }
     }
 
     /**
@@ -46,101 +50,94 @@ class Main extends PluginBase implements Listener{
      * @param array $args
      * @return bool
      */
-    public function onCommand(CommandSender $sender, Command $cmd, string $label, array $args): bool{
-		if($cmd->getName() == "discord"){
-			if($this->commandopt){
-				if(!isset($args[0])) {
-					$sender->sendMessage(C::RED."Please provide an argument! Usage: /discord (message).");
-				}
-				else{
-					$format = str_replace(['{player}', '{message}'], [$sender->getName(), implode(" ", $args)], $this->chatformat);
-					$this->sendMessage($this->chaturl, $format, $sender->getName(), $this->chatuser);
-				}
-			}
-			else{
-				$sender->sendMessage(C::RED."Sorry, but the owner disabled this option.");
-			}
-		}
-	return true;
-	}
-	
-	private function setvars(){
-    	$this->saveDefaultConfig();
-	    if(key_exists("Version", $this->getConfig()->getAll())){
-	       if($this->configversion !== $this->getConfig()->get("Version")){
-	           $this->getLogger()->critical("Please update your config!");
-	           $this->setEnabled(false);
-	           return;
-           }
+    public function onCommand(CommandSender $sender, Command $cmd, string $label, array $args): bool
+    {
+        if ($cmd->getName() == "discord") {
+            if ($this->commandopt) {
+                if (!isset($args[0])) {
+                    $sender->sendMessage(C::RED . "Please provide an argument! Usage: /discord (message).");
+                } else {
+                    $format = str_replace(['{player}', '{message}'], [$sender->getName(), implode(" ", $args)], $this->chatformat);
+                    $this->sendMessage($this->chaturl, $format, $sender->getName(), $this->chatuser);
+                }
+            } else {
+                $sender->sendMessage(C::RED . "Sorry, but the owner disabled this option.");
+            }
         }
-        else{
+        return true;
+    }
+
+    private function setvars()
+    {
+        $this->saveDefaultConfig();
+        if (key_exists("Version", $this->getConfig()->getAll())) {
+            if ($this->configversion !== $this->getConfig()->get("Version")) {
+                $this->getLogger()->critical("Please update your config!");
+                $this->setEnabled(false);
+                return;
+            }
+        } else {
             $this->getLogger()->critical("Please update your config!");
             $this->setEnabled(false);
             return;
         }
-        foreach ($this->getConfig()->getAll() as $item){
-            if(!isset($item) OR $item === ""){
+        foreach ($this->getConfig()->getAll() as $item) {
+            if (!isset($item) OR $item === "") {
                 $this->getLogger()->info("Please edit your config");
                 $this->setEnabled(false);
                 return;
             }
         }
-		$this->reloadConfig();
-		$this->webhook = $this->getConfig()->get("webhook_url");
-		$this->username = $this->getConfig()->get("username");
-		$this->startupopt = $this->getConfig()->get("start_message");
-		$this->shutdownopt = $this->getConfig()->get("shutdown_message");
-		$this->joinopt = $this->getConfig()->get("join_message");
-		$this->quitopt = $this->getConfig()->get("quit_message");
-		$this->deathopt = $this->getConfig()->get("death_message");
-		$this->debugopt = $this->getConfig()->get("debug");
-		$this->commandopt = $this->getConfig()->get("command");
-		$this->chatformat = $this->getConfig()->get("chat_format");
-		$this->chatprefix = $this->getConfig()->get("chat_prefix");
-		$this->chatopt = $this->getConfig()->get("chat");
-		
-			//Some statements
-			if($this->getConfig()->get("chat_username") === "0"){
-				$this->chatuser = $this->username;
-			}
-			elseif($this->getConfig()->get("chat_username") !== "0"){
-				$this->chatuser = $this->getConfig()->get("chat_username");
-			}
-			if($this->getConfig()->get("chat_url") === "0"){
-				$this->chaturl = $this->webhook;
-			}
-			elseif($this->getConfig()->get("chat_url") !== "0"){
-				$this->chaturl = $this->getConfig()->get("chat_url");
-			}
-	}
+        $this->reloadConfig();
+        $this->webhook = $this->getConfig()->get("webhook_url");
+        $this->username = $this->getConfig()->get("username");
+        $this->startupopt = $this->getConfig()->get("start_message");
+        $this->shutdownopt = $this->getConfig()->get("shutdown_message");
+        $this->joinopt = $this->getConfig()->get("join_message");
+        $this->quitopt = $this->getConfig()->get("quit_message");
+        $this->deathopt = $this->getConfig()->get("death_message");
+        $this->debugopt = $this->getConfig()->get("debug");
+        $this->commandopt = $this->getConfig()->get("command");
+        $this->chatformat = $this->getConfig()->get("chat_format");
+        $this->chatprefix = $this->getConfig()->get("chat_prefix");
+        $this->chatopt = $this->getConfig()->get("chat");
 
-	public function notify($player, $result){
-        if($player === "nolog"){
+        //Some statements
+        if ($this->getConfig()->get("chat_username") === "0") {
+            $this->chatuser = $this->username;
+        } elseif ($this->getConfig()->get("chat_username") !== "0") {
+            $this->chatuser = $this->getConfig()->get("chat_username");
+        }
+        if ($this->getConfig()->get("chat_url") === "0") {
+            $this->chaturl = $this->webhook;
+        } elseif ($this->getConfig()->get("chat_url") !== "0") {
+            $this->chaturl = $this->getConfig()->get("chat_url");
+        }
+    }
+
+    public function notify($player, $result)
+    {
+        if ($player === "nolog") {
             return;
-        }
-        elseif ($player === "CONSOLE"){
+        } elseif ($player === "CONSOLE") {
             $player = new ConsoleCommandSender();
-        }
-        else{
+        } else {
             $playerinstance = $this->getServer()->getPlayerExact($player);
-            if ($playerinstance === null){
+            if ($playerinstance === null) {
                 return;
-            }
-            else{
+            } else {
                 $player = $playerinstance;
             }
         }
-        if($result["success"]) {
-            $player->sendMessage(C::AQUA."[Discord-MCPE] ".C::GREEN."Discord message was send!");
-        }
-        else{
-            if($this->getConfig()->get("debug")){
-                $this->getLogger()->error(C::RED."Error: ".$result["Error"]);
+        if ($result["success"]) {
+            $player->sendMessage(C::AQUA . "[Discord-MCPE] " . C::GREEN . "Discord message was send!");
+        } else {
+            if ($this->getConfig()->get("debug")) {
+                $this->getLogger()->error(C::RED . "Error: " . $result["Error"]);
+            } else {
+                $this->getLogger()->warning(C::RED . "Something strange happened. Set debug in config to true to get error message");
             }
-            else{
-                $this->getLogger()->warning(C::RED."Something strange happened. Set debug in config to true to get error message");
-            }
-            $player->sendMessage(C::AQUA."[Discord-MCPE] ".C::GREEN."Discord message wasn't send!");
+            $player->sendMessage(C::AQUA . "[Discord-MCPE] " . C::GREEN . "Discord message wasn't send!");
         }
 
     }
@@ -151,12 +148,13 @@ class Main extends PluginBase implements Listener{
      * @param string $player
      * @param null $username
      */
-    public function sendMessage($webhook, $message, string $player = "nolog", $username = null){
-	    if(!isset($username)){
-	        $username = $this->username;
+    public function sendMessage($webhook, $message, string $player = "nolog", $username = null)
+    {
+        if (!isset($username)) {
+            $username = $this->username;
         }
-	    $curlopts = [
-	        "content" => $message,
+        $curlopts = [
+            "content" => $message,
             "username" => $username
         ];
         $this->getServer()->getScheduler()->scheduleAsyncTask(new Tasks\SendTaskAsync($player, $webhook, serialize($curlopts)));

--- a/src/Niekert/DiscordMCPE/Main.php
+++ b/src/Niekert/DiscordMCPE/Main.php
@@ -16,11 +16,11 @@ class Main extends PluginBase implements Listener
 
     public $webhook, $username, $startupopt, $shutdownopt, $joinopt, $quitopt, $deathopt, $debugopt, $commandopt, $chaturl, $chatformat, $chatprefix, $chatopt, $chatuser, $pp;
 
-    private $configversion = "1.0.2";
+    private $configversion = '1.0.2';
 
     public function onLoad()
     {
-        $this->getLogger()->info("Plugin loading");
+        $this->getLogger()->info('Plugin Loading');
     }
 
     public function onEnable()
@@ -37,16 +37,16 @@ class Main extends PluginBase implements Listener
             }
         }
         $this->getServer()->getPluginManager()->registerEvents(new EventListener($this), $this);
-        $this->getLogger()->info(C::GREEN . "Plugin Enabled");
-        if ($this->getConfig()->get("start_message") !== "0") {
-            $this->sendMessage($this->webhook, $this->startupopt, "CONSOLE");
+        $this->getLogger()->info(C::GREEN . 'Plugin Enabled');
+        if ($this->getConfig()->get('start_message') !== '0') {
+            $this->sendMessage($this->webhook, $this->startupopt, 'CONSOLE');
         }
     }
 
     public function onDisable()
     {
-        $this->getLogger()->info(C::RED . "Plugin Disabled");
-        if ($this->shutdownopt !== "0" AND !$this->isEnabled()) {
+        $this->getLogger()->info(C::RED . 'Plugin Disabled');
+        if ($this->shutdownopt !== '0' AND !$this->isEnabled()) {
             $this->sendMessage($this->webhook, $this->shutdownopt);
         }
     }
@@ -60,24 +60,24 @@ class Main extends PluginBase implements Listener
      */
     public function onCommand(CommandSender $sender, Command $cmd, string $label, array $args): bool
     {
-        if ($cmd->getName() == "discord") {
+        if ($cmd->getName() == 'discord') {
             if ($this->commandopt) {
                 $ppa = $this->getServer()->getPluginManager()->getPlugin('PurePerms');
                 if (!isset($args[0])) {
-                    $sender->sendMessage(C::RED . "Please provide an argument! Usage: /discord (message).");
+                    $sender->sendMessage(C::RED . 'Please provide an argument! Usage: /discord (message).');
                 } elseif ($this->pp !== null) {
                     if ($sender instanceof Player) {
-                        $format = str_replace(['{rank}', '{player}', '{message}'], [C::clean($ppa->getUserDataMgr()->getGroup($sender)), $sender->getName(), implode(" ", $args)], $this->chatformat);
+                        $format = str_replace(['{rank}', '{player}', '{message}'], [C::clean($ppa->getUserDataMgr()->getGroup($sender)), $sender->getName(), implode(' ', $args)], $this->chatformat);
                         $this->sendMessage($this->chaturl, $format, $sender->getName(), $this->chatuser);
                     } else {
                         $this->getServer()->getLogger()->notice('[Discord-MCPE] ' . C::RED . 'You cannot execute this command as console!');
                     }
                 } else {
-                    $format = str_replace(['{player}', '{message}'], [C::clean($sender->getName()), implode(" ", $args)], $this->chatformat);
+                    $format = str_replace(['{player}', '{message}'], [C::clean($sender->getName()), implode(' ', $args)], $this->chatformat);
                     $this->sendMessage($this->chaturl, $format, $sender->getName(), $this->chatuser);
                 }
             } else {
-                $sender->sendMessage(C::RED . "Sorry, but the owner disabled this option.");
+                $sender->sendMessage(C::RED . 'Sorry, but the owner disabled this option.');
             }
         }
         return true;
@@ -86,49 +86,49 @@ class Main extends PluginBase implements Listener
     private function setvars()
     {
         $this->saveDefaultConfig();
-        if (key_exists("Version", $this->getConfig()->getAll())) {
-            if ($this->configversion !== $this->getConfig()->get("Version")) {
-                $this->getLogger()->critical("Please update your config!");
+        if (key_exists('Version', $this->getConfig()->getAll())) {
+            if ($this->configversion !== $this->getConfig()->get('Version')) {
+                $this->getLogger()->critical('Please update your config!');
                 $this->setEnabled(false);
                 return;
             }
         } else {
-            $this->getLogger()->critical("Please update your config!");
+            $this->getLogger()->critical('Please update your config!');
             $this->setEnabled(false);
             return;
         }
         foreach ($this->getConfig()->getAll() as $item) {
-            if (!isset($item) OR $item === "") {
-                $this->getLogger()->info("Please edit your config");
+            if (!isset($item) OR $item === '') {
+                $this->getLogger()->info('Please edit your config!');
                 $this->setEnabled(false);
                 return;
             }
         }
         $this->reloadConfig();
-        $this->webhook = $this->getConfig()->get("webhook_url");
-        $this->username = $this->getConfig()->get("username");
-        $this->startupopt = $this->getConfig()->get("start_message");
-        $this->shutdownopt = $this->getConfig()->get("shutdown_message");
-        $this->joinopt = $this->getConfig()->get("join_message");
-        $this->quitopt = $this->getConfig()->get("quit_message");
-        $this->deathopt = $this->getConfig()->get("death_message");
-        $this->debugopt = $this->getConfig()->get("debug");
-        $this->commandopt = $this->getConfig()->get("command");
-        $this->chatformat = $this->getConfig()->get("chat_format");
-        $this->chatprefix = $this->getConfig()->get("chat_prefix");
-        $this->chatopt = $this->getConfig()->get("chat");
-        $this->pp = $this->getConfig()->get("pureperms");
+        $this->webhook = $this->getConfig()->get('webhook_url');
+        $this->username = $this->getConfig()->get('username');
+        $this->startupopt = $this->getConfig()->get('start_message');
+        $this->shutdownopt = $this->getConfig()->get('shutdown_message');
+        $this->joinopt = $this->getConfig()->get('join_message');
+        $this->quitopt = $this->getConfig()->get('quit_message');
+        $this->deathopt = $this->getConfig()->get('death_message');
+        $this->debugopt = $this->getConfig()->get('debug');
+        $this->commandopt = $this->getConfig()->get('command');
+        $this->chatformat = $this->getConfig()->get('chat_format');
+        $this->chatprefix = $this->getConfig()->get('chat_prefix');
+        $this->chatopt = $this->getConfig()->get('chat');
+        $this->pp = $this->getConfig()->get('pureperms');
 
         //Some statements
-        if ($this->getConfig()->get("chat_username") === "0") {
+        if ($this->getConfig()->get('chat_username') === '0') {
             $this->chatuser = $this->username;
-        } elseif ($this->getConfig()->get("chat_username") !== "0") {
-            $this->chatuser = $this->getConfig()->get("chat_username");
+        } elseif ($this->getConfig()->get('chat_username') !== '0') {
+            $this->chatuser = $this->getConfig()->get('chat_username');
         }
-        if ($this->getConfig()->get("chat_url") === "0") {
+        if ($this->getConfig()->get('chat_url') === '0') {
             $this->chaturl = $this->webhook;
-        } elseif ($this->getConfig()->get("chat_url") !== "0") {
-            $this->chaturl = $this->getConfig()->get("chat_url");
+        } elseif ($this->getConfig()->get('chat_url') !== '0') {
+            $this->chaturl = $this->getConfig()->get('chat_url');
         }
     }
 
@@ -138,9 +138,9 @@ class Main extends PluginBase implements Listener
      */
     public function notify($player, $result)
     {
-        if ($player === "nolog") {
+        if ($player === 'nolog') {
             return;
-        } elseif ($player === "CONSOLE") {
+        } elseif ($player === 'CONSOLE') {
             $player = new ConsoleCommandSender();
         } else {
             $playerinstance = $this->getServer()->getPlayerExact($player);
@@ -150,15 +150,15 @@ class Main extends PluginBase implements Listener
                 $player = $playerinstance;
             }
         }
-        if ($result["success"]) {
-            $player->sendMessage(C::AQUA . "[Discord-MCPE] " . C::GREEN . "Discord message was sent!");
+        if ($result['success']) {
+            $player->sendMessage(C::AQUA . '[Discord-MCPE] ' . C::GREEN . 'Discord message was sent!');
         } else {
-            if ($this->getConfig()->get("debug")) {
-                $this->getLogger()->error(C::RED . "Error: " . $result["Error"]);
+            if ($this->getConfig()->get('debug')) {
+                $this->getLogger()->error(C::RED . 'Error: ' . $result['Error']);
             } else {
-                $this->getLogger()->warning(C::RED . "Something strange happened. Set debug in config to true to get error message");
+                $this->getLogger()->warning(C::RED . 'Something strange happened. Set debug in config to true to get error message');
             }
-            $player->sendMessage(C::AQUA . "[Discord-MCPE] " . C::GREEN . "Discord message wasn't send!");
+            $player->sendMessage(C::AQUA . '[Discord-MCPE] ' . C::GREEN . 'Discord message wasn\'t sent!');
         }
     }
 
@@ -168,14 +168,14 @@ class Main extends PluginBase implements Listener
      * @param string $player
      * @param null $username
      */
-    public function sendMessage($webhook, $message, string $player = "nolog", $username = null)
+    public function sendMessage($webhook, $message, string $player = 'nolog', $username = null)
     {
         if (!isset($username)) {
             $username = $this->username;
         }
         $curlopts = [
-            "content" => $message,
-            "username" => $username
+            'content' => $message,
+            'username' => $username
         ];
         $this->getServer()->getScheduler()->scheduleAsyncTask(new Tasks\SendTaskAsync($player, $webhook, serialize($curlopts)));
     }

--- a/src/Niekert/DiscordMCPE/Tasks/SendTaskAsync.php
+++ b/src/Niekert/DiscordMCPE/Tasks/SendTaskAsync.php
@@ -37,15 +37,15 @@ class SendTaskAsync extends AsyncTask
         //Messy code incoming
         $responsejson = json_decode($response, true);
         $success = false;
-        $error = "IDK What happened";
-        if ($curlerror != "") {
+        $error = 'IDK What happened';
+        if ($curlerror != '') {
             $error = $curlerror;
         } elseif (curl_getinfo($curl, CURLINFO_HTTP_CODE) != 204) {
             $error = $responsejson['message'];
-        } elseif (curl_getinfo($curl, CURLINFO_HTTP_CODE) == 204 OR $response === "") {
+        } elseif (curl_getinfo($curl, CURLINFO_HTTP_CODE) == 204 OR $response === '') {
             $success = true;
         }
-        $result = ["Response" => $response, "Error" => $error, "success" => $success];
+        $result = ['Response' => $response, 'Error' => $error, 'success' => $success];
         $this->setResult($result, true);
     }
 

--- a/src/Niekert/DiscordMCPE/Tasks/SendTaskAsync.php
+++ b/src/Niekert/DiscordMCPE/Tasks/SendTaskAsync.php
@@ -38,13 +38,11 @@ class SendTaskAsync extends AsyncTask
         $responsejson = json_decode($response, true);
         $success = false;
         $error = "IDK What happened";
-        if($curlerror != ""){
+        if ($curlerror != "") {
             $error = $curlerror;
-        }
-        elseif (curl_getinfo($curl, CURLINFO_HTTP_CODE) != 204) {
+        } elseif (curl_getinfo($curl, CURLINFO_HTTP_CODE) != 204) {
             $error = $responsejson['message'];
-        }
-        elseif (curl_getinfo($curl, CURLINFO_HTTP_CODE) == 204 OR $response === ""){
+        } elseif (curl_getinfo($curl, CURLINFO_HTTP_CODE) == 204 OR $response === "") {
             $success = true;
         }
         $result = ["Response" => $response, "Error" => $error, "success" => $success];
@@ -57,10 +55,10 @@ class SendTaskAsync extends AsyncTask
     public function onCompletion(Server $server)
     {
         $plugin = $server->getPluginManager()->getPlugin('Discord-MCPE');
-        if(!$plugin instanceof Main){
+        if (!$plugin instanceof Main) {
             return;
         }
-        if(!$plugin->isEnabled()){
+        if (!$plugin->isEnabled()) {
             return;
         }
         $plugin->notify($this->player, $this->getResult());


### PR DESCRIPTION
Adds support for PurePerm ranks. (commits are done)
It was ALPHA7 which `:bool` was required for `onCommand()`, so you shouldn't allow APIs below that. I've removed APIs below ALPHA10 just to be safe, but you can add them back if you want.

Also changed double quotations to single apostrophe. It will just print whatever is inside ' ', instead of PHP checking for any variables inside with " ".

### PurePerms Enabled:
![image](https://user-images.githubusercontent.com/16523741/38168416-ccb7803c-34e6-11e8-9120-9bbf9ab5ec80.png)
![image](https://user-images.githubusercontent.com/16523741/38168418-daa15844-34e6-11e8-9282-e461d14513e1.png)

### PurePerms Missing, but Enabled:
![image](https://user-images.githubusercontent.com/16523741/38168419-ecbb1b96-34e6-11e8-9eb6-319b675ba6e2.png)

#### I've found an issue while testing:
If you use the `!` prefix with `chat: true`, it will send both the messages, one with `!` and one without `!`. 
Occurs in version 1.0.1, so before my modifications. I won't fix this.